### PR TITLE
APP-224: set image dimensions for front ticket action for image

### DIFF
--- a/fern/docs/pages/integrations/front.mdx
+++ b/fern/docs/pages/integrations/front.mdx
@@ -6,7 +6,7 @@ layout: overview
 
 Maven provides an integration that allows it to create tickets in Front via a Custom Action. Once triggered, a form will be used to collect name, email address, summary and description of the issue the user is facing via the chat experience.
 
-![Ticket Action Form](/docs/assets/front/05_Front_Ticket_Action_Form.png)
+<img src="/docs/assets/front/05_Front_Ticket_Action_Form.png" alt="Ticket Action Form" width="300" height="440">
 
 ## Configure Maven
 


### PR DESCRIPTION
The image is way too big as is. https://docs.mavenagi.com/integrations/front

Setting dimensions so it looks better.

<img width="1373" alt="Screenshot 2024-11-14 at 9 33 24 AM" src="https://github.com/user-attachments/assets/98865e99-3e11-4543-bb72-b2e90758d2f8">
