### PR TITLE
Update chat.mdx

### DIFF
--- a/fern/docs/pages/apps/surfaces/chat.mdx
+++ b/fern/docs/pages/apps/surfaces/chat.mdx
@@ -356,7 +356,7 @@ Follow these steps to configure Zendesk integration:
     - Uncheck **Webhook body data**
     - Check all **Webhook subscriptions**
     - Click **Save**
-    - After saving, note the **Webhook ID** from the URL (it will be in the format `https://admin.zendesk.com/admin/integrations/webhooks/{webhookId}`)
+    - After saving, note the **Webhook ID** and **Shared Secret** which are displayed on the page below the **Integration ID** field.
   </Step>
   <Step title="Generate API Key">
     - Navigate to the **API Keys** tab


### PR DESCRIPTION
Added clarity on where to find webhook ID, as current instructions are incorrect.