### PR TITLE
fix: update chat user auth requirements

### DIFF
--- a/fern/docs/pages/apps/surfaces/chat.mdx
+++ b/fern/docs/pages/apps/surfaces/chat.mdx
@@ -759,12 +759,7 @@ Maven Chat now accepts signed and encrypted user authentication, allowing our cu
 #### User Data Requirements
 
 The user data object must include:
-- `firstName` - User's first name
-- `lastName` - User's last name
-- `id` - User's unique identifier (UUID)
-- At least one of:
-  - `phoneNumber` - User's phone number
-  - `email` - User's email address
+- `id` - A unique identifier for the user
 - Additional fields will be included in the Maven user that's created
 
 #### Generating User Authentication Token
@@ -778,12 +773,7 @@ import { SignJWT, EncryptJWT } from 'jose';
 
 async function secureUserData(userData: Record<string, string> & {
  id: string
- firstName: string
- lastName: string
-} & (
- { email: string, phoneNumber?: string } |
- { email?: string, phoneNumber: string }
-)) {
+}) {
  // 1. Sign the user data with your private key (ES256 algorithm)
  const signedJWT = await new SignJWT(userData)
    .setProtectedHeader({ alg: 'ES256' })


### PR DESCRIPTION
Updated the chat auth docs to reflect the latest requirements: the only required field in the JWT is `id`.