### PR TITLE
feat(doc): add proactive messages docs for chat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,5 @@ dist
 # macOS system files
 .DS_Store
 .DS_Store?
+
+.idea/

--- a/fern/docs/pages/apps/surfaces/chat.mdx
+++ b/fern/docs/pages/apps/surfaces/chat.mdx
@@ -177,6 +177,11 @@ window.Maven.ChatWidget.hide();
 
 // Show the chat button
 window.Maven.ChatWidget.show();
+
+// Only available if **appendNewMessage API** is enabled in the chat app settings under **Miscellaneous**
+window.Maven.ChatWidget.appendNewMessage({
+  text: 'Hello, this is a test message'
+});
 ```
 
 ## Live Agent Handoff
@@ -924,3 +929,27 @@ async function secureUserData(userData: Record<string, string> & {
  return encryptedJWT;
 }
 ```
+## Pushing Messages Programmatically
+
+Maven Chat now allows you to push messages to the chat session from your backend.
+This can be used to notify the user of updates or to provide additional context to the user.
+This feature is disabled by default and must be enabled in the chat app settings
+under **Miscellaneous** (**Enable appendNewMessage API**).
+
+#### Requirements
+
+- Enable **appendNewMessage API** in the chat app settings under **Miscellaneous**
+
+#### Configuration
+
+The handoff configuration requires two steps:
+
+<Steps>
+  <Step title="API example to push a message to the chat widget">
+    ```javascript
+    Maven.ChatWidget.appendNewMessage({
+      text: 'Hello, this is a message'
+    });
+    ```
+  </Step>
+</Steps>


### PR DESCRIPTION
This pull request updates the documentation for the Maven Chat widget to introduce and explain the new `appendNewMessage` API, which allows programmatic pushing of messages to the chat session. The changes clarify the requirements for enabling this feature and provide example usage.

**New feature documentation:**

* Added a new section, "Pushing Messages Programmatically," describing the `appendNewMessage` API, its purpose, and the requirement to enable it in the chat app settings under **Miscellaneous**.

**Usage example:**

* Added example code demonstrating how to use `window.Maven.ChatWidget.appendNewMessage` to push a message to the chat widget, along with a note about the feature's availability and configuration.