### PR TITLE
feat(docs): update docs to explain how to external_id can be configured for Zendesk

### DIFF
--- a/fern/docs/pages/apps/surfaces/chat.mdx
+++ b/fern/docs/pages/apps/surfaces/chat.mdx
@@ -664,8 +664,16 @@ Create a handoff configuration object with the following structure:
   appId: 'your_zendesk_app_id',
   webhookId: 'your-webhook-id',
   mavenContextFieldId: "your-field-id",
+  shouldForceUserAuthentication: true
+  forceUserAuthenticationApiEmail: "your api email"
+  forceUserAuthenticationApiToken: "your api token"
 }
 ```
+
+To correctly set the email address on the contact, you need to provide the email address of the API user and the API token for the API user.
+To customize the external id in Zendesk, set the property `externalId` on the `signedUserData` property of the chat configuration.
+By default, `external_id` is set to the user's `id` on `signedUserData`.
+
 
 2. Convert to JSON and add to Maven:
    - Convert the object to a JSON string
@@ -682,6 +690,10 @@ Create a handoff configuration object with the following structure:
 | `appId` | string | Yes | - | Your Zendesk app ID |
 | `webhookId` | string | Yes | - | Your Zendesk webhook ID (found in webhook URL after creation) |
 | `mavenContextFieldId` | string    | Yes      | -       | Your Zendesk field ID (found in fields list after creation)   |
+| `shouldForceUserAuthentication` | boolean    | No      | -       | Whether to force user authentication when creating users via the API   |
+| `forceUserAuthenticationApiEmail` | string    | No      | -       | The email address of the API user    |
+| `forceUserAuthenticationApiToken` | string    | No      | -       | The API token for the API user    |
+
 
 ### Front Configuration
 


### PR DESCRIPTION
This pull request updates the documentation for configuring Zendesk handoff in the chat app, focusing on improved user authentication options and clarifying how to set user identifiers. The main changes include new configuration options for forcing user authentication and documentation updates to explain their usage.

**User authentication configuration:**

* Added three new configuration fields: `shouldForceUserAuthentication`, `forceUserAuthenticationApiEmail`, and `forceUserAuthenticationApiToken` to support forced user authentication when creating users via the API. [[1]](diffhunk://#diff-3f0ded06cd7e0b7d356c35c0ebd31ed376a0a1c7e7b5f63e289bef8f709838b2R667-R677) [[2]](diffhunk://#diff-3f0ded06cd7e0b7d356c35c0ebd31ed376a0a1c7e7b5f63e289bef8f709838b2R693-R696)

**Documentation improvements:**

* Updated the documentation to explain the need to provide the API user's email and token for setting the email address on the contact, and clarified how to customize the `externalId` in Zendesk via the `signedUserData` property.
* Extended the configuration options table to include the new authentication fields, describing their purpose and usage.